### PR TITLE
environment variable configuration option

### DIFF
--- a/lib/project-runner.coffee
+++ b/lib/project-runner.coffee
@@ -7,6 +7,7 @@ class ProjectRunnerBuildr
 
   constructor: ->
     shell.cd atom.project.path
+    atom.config.setDefaults('project-runner', environmentVariables:'')
 
   command:(state) ->
     for file in shell.ls '*file'#|config.*
@@ -48,6 +49,13 @@ class ProjectRunner
     if script is undefined
       @runnerView.show(false, 'no such file: Makefile or Rakefile\n')
       return
+
+    environmentVariables = JSON.parse(atom.config.get("project-runner.environmentVariables"))
+    for variable in environmentVariables.env
+      variableSplit = variable.split('=')
+      name = variableSplit[0]
+      value = variableSplit[1]
+      shell.env[name] = value
 
     @execute(script)
 


### PR DESCRIPTION
As far as I am concerned, in order to set environment variables you need to run atom from the terminal.  It then inherits the terminal's environment. I added a configuration option to load supplemental environment variables.  These will override any existing variables with the same name.
