### PR TITLE
environment variable configuration option

### DIFF
--- a/lib/project-runner.coffee
+++ b/lib/project-runner.coffee
@@ -50,7 +50,7 @@ class ProjectRunner
       @runnerView.show(false, 'no such file: Makefile or Rakefile\n')
       return
 
-    environmentVariables = JSON.parse(atom.config.get("project-runner.environmentVariables"))
+    environmentVariables = JSON.parse('{"env":['+atom.config.get("project-runner.environmentVariables")+"]}")
     for variable in environmentVariables.env
       variableSplit = variable.split('=')
       name = variableSplit[0]


### PR DESCRIPTION
I added a configuration option to load supplemental environment variables. These will override any existing variables with the same name.  I figured others might find this useful.

example config value: "GOPATH=/Users/mcanders/Dropbox/go", "PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
